### PR TITLE
ci: publish builder stage image to ghcr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 # This is a basic workflow to help in CI
 name: Polycube CI
 
+permissions:
+  contents: read
+  packages: write
+
 # Controls when the action will run. Triggers the workflow on schedule events
 on:
   push:
@@ -156,10 +160,13 @@ jobs:
         id: setup
         run: |
           repo=${{ env.app-registry }}/${{ matrix.name }}
+          ghcr_repo=ghcr.io/${{ github.repository_owner }}/${{ matrix.name }}-builder
           if [[ "${{ needs.configure.outputs.state }}" == "dev" ]]; then
             echo "::set-output name=repo-tags::$repo:${{ needs.configure.outputs.ref }}"
+            echo "::set-output name=ghcr-builder-tags::$ghcr_repo:${{ needs.configure.outputs.ref }}"
           else
             echo "::set-output name=repo-tags::$repo:${{ needs.configure.outputs.ref }},$repo:latest"
+            echo "::set-output name=ghcr-builder-tags::$ghcr_repo:${{ needs.configure.outputs.ref }},$ghcr_repo:latest"
           fi
 
       - name: Docker login
@@ -168,11 +175,32 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
+      - name: Docker login GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push builder image
+        uses: docker/build-push-action@v2
+        with:
+            context: ./
+            file: ./Dockerfile
+            builder: ${{ steps.buildx.outputs.name }}
+            build-args: |
+              DEFAULT_MODE=${{ matrix.mode }}
+            target: builder
+            push: true
+            tags: ${{ steps.setup.outputs.ghcr-builder-tags }}
+            cache-from: type=local,src=/tmp/.buildx-cache
+            cache-to: type=local,dest=/tmp/.buildx-cache
+
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-            context: ./ 
+            context: ./
             file: ./Dockerfile
             builder: ${{ steps.buildx.outputs.name }}
             build-args: |


### PR DESCRIPTION
## Summary
- allow the CI workflow to push images to GHCR
- add steps to tag and publish the builder stage image for each build matrix entry

## Testing
- not run (CI change only)


------
https://chatgpt.com/codex/tasks/task_b_68d4b17fbd248326b29460df918050cd