### PR TITLE
Centralize eBPF buffer polling in polycubed

### DIFF
--- a/src/polycubed/src/CMakeLists.txt
+++ b/src/polycubed/src/CMakeLists.txt
@@ -52,6 +52,7 @@ set(polycubed_sources
   transparent_cube_tc.cpp
   transparent_cube_xdp.cpp
   controller.cpp
+  ebpf_event_loop.cpp
   extiface.cpp
   extiface_tc.cpp
   extiface_xdp.cpp

--- a/src/polycubed/src/controller.h
+++ b/src/polycubed/src/controller.h
@@ -22,7 +22,6 @@
 #include <functional>
 #include <map>
 #include <string>
-#include <thread>
 #include <vector>
 
 #include <api/BPF.h>
@@ -88,23 +87,17 @@ class Controller {
 
   uint32_t id_;
 
-  void start();
-  void stop();
-
   std::unique_ptr<ebpf::BPFArrayTable<metadata>> metadata_table_;
-
-  bool stop_;
 
   std::string buffer_name_;
   ebpf::BPF buffer_module_;
   ebpf::BPF rx_module_;
   int fd_tx_;
   int fd_rx_;
+  int perf_handle_;
 
   std::unique_ptr<viface::VIface> iface_;
   int ctrl_rx_md_index_;  // next position to write in the metadata map
-
-  std::unique_ptr<std::thread> pkt_in_thread_;
 
   static std::map<int, const packet_in_cb &> cbs_;
   static std::mutex cbs_mutex_;  // protects the cbs_ container

--- a/src/polycubed/src/cube_tc.h
+++ b/src/polycubed/src/cube_tc.h
@@ -66,11 +66,11 @@ class CubeTC : public Cube {
   void unload(ebpf::BPF &bpf, ProgramType type);
 
   static void send_packet_ns_span_mode(void *cb_cookie, void *data, int data_size);
-  void start_thread_span_mode();
-  void stop_thread_span_mode();
-  bool stop_thread_;
-  std::unique_ptr<std::thread> pkt_in_thread_;
+  void attach_span_handler();
+  void detach_span_handler();
+  int span_event_handle_;
 
+  void reload_all() override;
   void set_span(const bool value) override;
 
  private:

--- a/src/polycubed/src/datapath_log.h
+++ b/src/polycubed/src/datapath_log.h
@@ -22,7 +22,6 @@
 #include <iostream>
 #include <regex>
 #include <string>
-#include <thread>
 #include <vector>
 
 #include <api/BPF.h>
@@ -43,9 +42,6 @@ class DatapathLog {
   void register_cb(int id, const log_msg_cb &cb);
   void unregister_cb(int id);
 
-  void start();
-  void stop();
-
   static void call_back_proxy(void *cb_cookie, void *data, int data_size);
   static std::string replace_string(std::string &subject,
                                     const std::string &search,
@@ -57,12 +53,11 @@ class DatapathLog {
 
  private:
   DatapathLog();
-  std::unique_ptr<std::thread> dbg_thread_;
   ebpf::BPF perf_buffer_;
   std::map<uint32_t, const log_msg_cb &> cbs_;
   std::mutex cbs_mutex_;  // protects the cbs_ container
   std::shared_ptr<spdlog::logger> logger;
-  bool stop_;
+  int perf_handle_;
   std::string base_code_;
 };
 

--- a/src/polycubed/src/ebpf_event_loop.cpp
+++ b/src/polycubed/src/ebpf_event_loop.cpp
@@ -1,0 +1,278 @@
+#include "ebpf_event_loop.h"
+
+#include <chrono>
+#include <cstring>
+#include <errno.h>
+#include <utility>
+#include <vector>
+
+namespace polycube {
+namespace polycubed {
+
+EbpfEventLoop &EbpfEventLoop::get_instance() {
+  static EbpfEventLoop instance;
+  return instance;
+}
+
+EbpfEventLoop::EbpfEventLoop()
+    : next_id_(1),
+      running_(false),
+      stop_requested_(false),
+      sources_changed_(false),
+      poll_timeout_ms_(100) {}
+
+EbpfEventLoop::~EbpfEventLoop() {
+  Stop();
+}
+
+void EbpfEventLoop::Start() {
+  std::lock_guard<std::mutex> guard(mutex_);
+  if (running_)
+    return;
+
+  stop_requested_ = false;
+  running_ = true;
+  worker_ = std::thread(&EbpfEventLoop::Run, this);
+}
+
+void EbpfEventLoop::Stop() {
+  {
+    std::lock_guard<std::mutex> guard(mutex_);
+    if (!running_)
+      return;
+    stop_requested_ = true;
+  }
+  cv_.notify_all();
+  if (worker_.joinable())
+    worker_.join();
+  running_ = false;
+  stop_requested_ = false;
+}
+
+int EbpfEventLoop::RegisterPerfBuffer(int map_fd, const PerfCallback &callback,
+                                      void *cookie, size_t page_cnt) {
+  Start();
+
+  int err = 0;
+  int handle = next_id_.fetch_add(1);
+  std::shared_ptr<PerfEventSource> source = PerfEventSource::Create(
+      handle, map_fd, callback, cookie, page_cnt, GetLogger(), &err);
+  if (!source || err) {
+    return err ? err : -EINVAL;
+  }
+
+  {
+    std::lock_guard<std::mutex> guard(mutex_);
+    sources_.insert(std::make_pair(handle, source));
+    sources_changed_ = true;
+  }
+  cv_.notify_all();
+  return handle;
+}
+
+int EbpfEventLoop::RegisterRingBuffer(int map_fd, const RingCallback &callback,
+                                      void *cookie) {
+  Start();
+
+  int err = 0;
+  int handle = next_id_.fetch_add(1);
+  std::shared_ptr<RingEventSource> source = RingEventSource::Create(
+      handle, map_fd, callback, cookie, GetLogger(), &err);
+  if (!source || err) {
+    return err ? err : -EINVAL;
+  }
+
+  {
+    std::lock_guard<std::mutex> guard(mutex_);
+    sources_.insert(std::make_pair(handle, source));
+    sources_changed_ = true;
+  }
+  cv_.notify_all();
+  return handle;
+}
+
+void EbpfEventLoop::Unregister(int handle) {
+  std::shared_ptr<EventSource> source;
+  {
+    std::lock_guard<std::mutex> guard(mutex_);
+    std::map<int, std::shared_ptr<EventSource>>::iterator it =
+        sources_.find(handle);
+    if (it == sources_.end())
+      return;
+    source = it->second;
+    sources_.erase(it);
+    sources_changed_ = true;
+  }
+  cv_.notify_all();
+}
+
+EbpfEventLoop::EventSource::EventSource(int id) : id_(id) {}
+
+EbpfEventLoop::EventSource::~EventSource() {}
+
+int EbpfEventLoop::EventSource::id() const { return id_; }
+
+std::shared_ptr<EbpfEventLoop::PerfEventSource>
+EbpfEventLoop::PerfEventSource::Create(
+    int id, int map_fd, const PerfCallback &callback, void *cookie,
+    size_t page_cnt, std::shared_ptr<spdlog::logger> logger, int *err) {
+  std::shared_ptr<PerfEventSource> source(
+      new PerfEventSource(id, map_fd, callback, cookie, page_cnt, logger, err));
+  if (err && *err)
+    source.reset();
+  return source;
+}
+
+EbpfEventLoop::PerfEventSource::PerfEventSource(
+    int id, int map_fd, const PerfCallback &callback, void *cookie,
+    size_t page_cnt, std::shared_ptr<spdlog::logger> logger, int *err)
+    : EventSource(id),
+      buffer_(nullptr),
+      callback_(callback),
+      cookie_(cookie),
+      logger_(logger) {
+  buffer_ = perf_buffer__new(map_fd, page_cnt, &PerfEventSource::SampleTrampoline,
+                             &PerfEventSource::LostTrampoline, this, nullptr);
+  if (!buffer_) {
+    if (err)
+      *err = -errno;
+  } else if (err) {
+    *err = 0;
+  }
+}
+
+EbpfEventLoop::PerfEventSource::~PerfEventSource() {
+  if (buffer_)
+    perf_buffer__free(buffer_);
+}
+
+int EbpfEventLoop::PerfEventSource::Poll() {
+  if (!buffer_)
+    return -EINVAL;
+  return perf_buffer__poll(buffer_, 0);
+}
+
+void EbpfEventLoop::PerfEventSource::SampleTrampoline(void *ctx, int cpu,
+                                                      void *data,
+                                                      __u32 size) {
+  PerfEventSource *source = static_cast<PerfEventSource *>(ctx);
+  if (!source)
+    return;
+  if (source->callback_)
+    source->callback_(source->cookie_, data, static_cast<int>(size));
+}
+
+void EbpfEventLoop::PerfEventSource::LostTrampoline(void *ctx, int cpu,
+                                                    __u64 lost) {
+  PerfEventSource *source = static_cast<PerfEventSource *>(ctx);
+  if (!source || !source->logger_)
+    return;
+  source->logger_->warn("Lost {} perf buffer events on CPU {}", lost, cpu);
+}
+
+std::shared_ptr<EbpfEventLoop::RingEventSource>
+EbpfEventLoop::RingEventSource::Create(
+    int id, int map_fd, const RingCallback &callback, void *cookie,
+    std::shared_ptr<spdlog::logger> logger, int *err) {
+  std::shared_ptr<RingEventSource> source(
+      new RingEventSource(id, map_fd, callback, cookie, logger, err));
+  if (err && *err)
+    source.reset();
+  return source;
+}
+
+EbpfEventLoop::RingEventSource::RingEventSource(
+    int id, int map_fd, const RingCallback &callback, void *cookie,
+    std::shared_ptr<spdlog::logger> logger, int *err)
+    : EventSource(id),
+      buffer_(nullptr),
+      callback_(callback),
+      cookie_(cookie),
+      logger_(logger) {
+  buffer_ = ring_buffer__new(map_fd, &RingEventSource::SampleTrampoline, this,
+                             nullptr);
+  if (!buffer_) {
+    if (err)
+      *err = -errno;
+  } else if (err) {
+    *err = 0;
+  }
+}
+
+EbpfEventLoop::RingEventSource::~RingEventSource() {
+  if (buffer_)
+    ring_buffer__free(buffer_);
+}
+
+int EbpfEventLoop::RingEventSource::Poll() {
+  if (!buffer_)
+    return -EINVAL;
+  return ring_buffer__poll(buffer_, 0);
+}
+
+int EbpfEventLoop::RingEventSource::SampleTrampoline(void *ctx, void *data,
+                                                     size_t size) {
+  RingEventSource *source = static_cast<RingEventSource *>(ctx);
+  if (!source)
+    return 0;
+  if (source->callback_)
+    source->callback_(source->cookie_, data, size);
+  return 0;
+}
+
+void EbpfEventLoop::Run() {
+  std::unique_lock<std::mutex> lock(mutex_);
+  while (true) {
+    if (stop_requested_)
+      break;
+
+    if (sources_.empty()) {
+      cv_.wait(lock, [this]() { return stop_requested_ || !sources_.empty(); });
+      if (stop_requested_)
+        break;
+    }
+
+    std::vector<std::shared_ptr<EventSource>> snapshot;
+    snapshot.reserve(sources_.size());
+    for (std::map<int, std::shared_ptr<EventSource>>::const_iterator it =
+             sources_.begin();
+         it != sources_.end(); ++it) {
+      snapshot.push_back(it->second);
+    }
+
+    lock.unlock();
+
+    bool had_activity = false;
+    for (size_t i = 0; i < snapshot.size(); ++i) {
+      int ret = snapshot[i]->Poll();
+      if (ret > 0) {
+        had_activity = true;
+      } else if (ret < 0 && ret != -EINTR) {
+        std::shared_ptr<spdlog::logger> logger = GetLogger();
+        if (logger)
+          logger->error("Error polling eBPF buffer (handle {}): {}",
+                        snapshot[i]->id(), std::strerror(-ret));
+      }
+    }
+
+    lock.lock();
+
+    if (!had_activity) {
+      if (!stop_requested_) {
+        cv_.wait_for(lock, std::chrono::milliseconds(poll_timeout_ms_),
+                     [this]() { return stop_requested_ || sources_changed_; });
+      }
+    }
+    sources_changed_ = false;
+  }
+}
+
+std::shared_ptr<spdlog::logger> EbpfEventLoop::GetLogger() {
+  if (!logger_)
+    logger_ = spdlog::get("polycubed");
+  return logger_;
+}
+
+}  // namespace polycubed
+}  // namespace polycube
+

--- a/src/polycubed/src/ebpf_event_loop.h
+++ b/src/polycubed/src/ebpf_event_loop.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <condition_variable>
+#include <atomic>
+
+#include <spdlog/spdlog.h>
+#include <libbpf.h>
+
+#include <api/BPF.h>
+
+namespace polycube {
+namespace polycubed {
+
+class EbpfEventLoop {
+ public:
+  typedef std::function<void(void *, void *, int)> PerfCallback;
+  typedef std::function<void(void *, void *, size_t)> RingCallback;
+
+  static EbpfEventLoop &get_instance();
+
+  // Starts the event loop thread. It is automatically invoked on register if
+  // the loop is not running yet.
+  void Start();
+  void Stop();
+
+  int RegisterPerfBuffer(int map_fd, const PerfCallback &callback,
+                         void *cookie, size_t page_cnt = 64);
+
+  int RegisterRingBuffer(int map_fd, const RingCallback &callback,
+                         void *cookie);
+
+  void Unregister(int handle);
+
+ private:
+  EbpfEventLoop();
+  ~EbpfEventLoop();
+
+  EbpfEventLoop(const EbpfEventLoop &) = delete;
+  EbpfEventLoop &operator=(const EbpfEventLoop &) = delete;
+
+  class EventSource {
+   public:
+    explicit EventSource(int id);
+    virtual ~EventSource();
+    virtual int Poll() = 0;
+    int id() const;
+
+   private:
+    int id_;
+  };
+
+  class PerfEventSource : public EventSource {
+   public:
+    static std::shared_ptr<PerfEventSource> Create(
+        int id, int map_fd, const PerfCallback &callback, void *cookie,
+        size_t page_cnt, std::shared_ptr<spdlog::logger> logger, int *err);
+    ~PerfEventSource() override;
+    int Poll() override;
+
+   private:
+    PerfEventSource(int id, int map_fd, const PerfCallback &callback,
+                    void *cookie, size_t page_cnt,
+                    std::shared_ptr<spdlog::logger> logger, int *err);
+    static void SampleTrampoline(void *ctx, int cpu, void *data, __u32 size);
+    static void LostTrampoline(void *ctx, int cpu, __u64 lost);
+
+    struct perf_buffer *buffer_;
+    PerfCallback callback_;
+    void *cookie_;
+    std::shared_ptr<spdlog::logger> logger_;
+  };
+
+  class RingEventSource : public EventSource {
+   public:
+    static std::shared_ptr<RingEventSource> Create(
+        int id, int map_fd, const RingCallback &callback, void *cookie,
+        std::shared_ptr<spdlog::logger> logger, int *err);
+    ~RingEventSource() override;
+    int Poll() override;
+
+   private:
+    RingEventSource(int id, int map_fd, const RingCallback &callback,
+                    void *cookie, std::shared_ptr<spdlog::logger> logger,
+                    int *err);
+    static int SampleTrampoline(void *ctx, void *data, size_t size);
+
+    struct ring_buffer *buffer_;
+    RingCallback callback_;
+    void *cookie_;
+    std::shared_ptr<spdlog::logger> logger_;
+  };
+
+  void Run();
+  std::shared_ptr<spdlog::logger> GetLogger();
+
+  std::atomic<int> next_id_;
+  std::map<int, std::shared_ptr<EventSource>> sources_;
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  std::thread worker_;
+  bool running_;
+  bool stop_requested_;
+  bool sources_changed_;
+  int poll_timeout_ms_;
+  std::shared_ptr<spdlog::logger> logger_;
+};
+
+}  // namespace polycubed
+}  // namespace polycube


### PR DESCRIPTION
## Summary
- add a reusable EbpfEventLoop that polls libbpf perf and ring buffers on a shared thread
- update DatapathLog, Controller, and CubeTC to register their perf buffers with the new loop instead of spawning bespoke polling threads
- ensure span handlers detach/reattach during reloads and include the new component in the build

## Testing
- cmake -S . -B build *(fails: missing Pistache dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d7b403cd08832693377a89ae41d36d